### PR TITLE
Adding link to wiki page for Harvard+Library+Open+Source+Project+Cons…

### DIFF
--- a/github.tsv
+++ b/github.tsv
@@ -74,3 +74,4 @@ https://github.com/openscholar/openscholar
 https://github.com/penzance/canvas_python_sdk
 https://github.com/penzance/harvard-data-tools
 https://github.com/refinery-platform/refinery-platform
+https://wiki.harvard.edu/confluence/display/LibraryStaffDoc/Harvard+Library+Open+Source+Project+Considerations


### PR DESCRIPTION
…iderations

The Harvard Library Technology Services group has posted some useful information at https://wiki.harvard.edu/confluence/display/LibraryStaffDoc/Harvard+Library+Open+Source+Project+Considerations that we have used. This includes some factors to consider, as well as the license option that we have chosen (apache in most cases) for releasing code developed for library applications.