### PR TITLE
Added Strategic Data Project Repositories to list

### DIFF
--- a/github.tsv
+++ b/github.tsv
@@ -71,6 +71,15 @@ https://github.com/IQSS/UNF
 https://github.com/IQSS/Zelig
 https://github.com/onnela-lab/HX_python_for_research
 https://github.com/openscholar/openscholar
+https://github.com/OpenSDP/data-janitor-r
+https://github.com/OpenSDP/data-janitor-stata
+https://github.com/OpenSDP/OpenSDPsynthR
+https://github.com/OpenSDP/template-r
+https://github.com/OpenSDP/template-stata
+https://github.com/OpenSDP/college-going-stata
+https://github.com/OpenSDP/dataviz-r
+https://github.com/OpenSDP/college-going-r
+https://github.com/OpenSDP/faketucky
 https://github.com/penzance/canvas_python_sdk
 https://github.com/penzance/harvard-data-tools
 https://github.com/refinery-platform/refinery-platform


### PR DESCRIPTION
Added repositories owned by the [Strategic Data Project](https://sdp.cepr.harvard.edu/) at the [Center for Education Policy Research](https://cepr.harvard.edu/) at the [Harvard Graduate School of Education](https://www.gse.harvard.edu/).