### PR TITLE
fixing 404 on schema_MCZbase

### DIFF
--- a/github.tsv
+++ b/github.tsv
@@ -94,7 +94,7 @@ https://github.com/penzance/canvas_python_sdk
 https://github.com/penzance/harvard-data-tools
 https://github.com/refinery-platform/refinery-platform
 https://github.com/MCZbase/MCZbase
-https://github.com/MCZbase/schema_MCZbase
+https://github.com/MCZbase/DDL
 https://github.com/MCZbase/eDecViewer
 https://github.com/MCZbase/PreCapture
 https://github.com/MCZbase/DataShot_DesktopApp


### PR DESCRIPTION
Updating Museum of Comparative Zoology Repository, MCZbase/schema_MCZbase was moved to MCZbase/DDL.  Should fix IQSS/open-source-at-harvard#19
