### PR TITLE
edX-related repos at VPAL

### DIFF
--- a/github.tsv
+++ b/github.tsv
@@ -42,6 +42,11 @@ https://github.com/cid-harvard/product-space
 https://github.com/cid-harvard/py-ecomplexity
 https://github.com/cid-harvard/subnational-playbooks
 https://github.com/cid-harvard/visualization-notebook-templates
+https://github.com/Colin-Fredericks/edx_replace_staff
+https://github.com/Colin-Fredericks/hx-js
+https://github.com/Colin-Fredericks/hx-py
+https://github.com/Colin-Fredericks/hx-xml
+https://github.com/Colin-Fredericks/hx_util
 https://github.com/DRSC-FG/gene2function
 https://github.com/farhat-lab/gentb-site
 https://github.com/fasrc/helmod
@@ -88,6 +93,8 @@ https://github.com/harvardinformatics/ATAC-seq
 https://github.com/harvardinformatics/JAuth
 https://github.com/HarvardOpenData/propublica-data
 https://github.com/HarvardPL/shill
+https://github.com/HarvardX/edx_course_templater
+https://github.com/HarvardX/studio-advanced
 https://github.com/HBRGTech/daisy
 https://github.com/hms-dbmi/scde
 https://github.com/hms-dbmi/UpSetR


### PR DESCRIPTION
These contain tools we use to make courses on edX.org. Most are MIT-licensed, one is CC-BY because it's more text than code.